### PR TITLE
Request was sometimes incorrect

### DIFF
--- a/lib/rack/apimock.rb
+++ b/lib/rack/apimock.rb
@@ -9,6 +9,10 @@ module Rack
     end
 
     def call(env)
+      dup._call(env)
+    end
+
+    def _call(env)
       @status, @headers = 200, {}
       if env["CONTENT_TYPE"] =~ /application\/json/i
         @request_body = JSON.parse(env["rack.input"].gets) rescue nil


### PR DESCRIPTION
it's necessary to dup the middleware to be thread-safe.

workaround: http://railscasts.com/episodes/151-rack-middleware
